### PR TITLE
fix: Restore correct rust-version and improve semantic-release pattern

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -8,7 +8,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "sed -i '3s/version = \".*\"/version = \"${nextRelease.version}\"/' Cargo.toml"
+        "prepareCmd": "sed -i '/^name = \"dotsnapshot\"/,/^edition = \"2021\"/ s/^version = \".*\"/version = \"${nextRelease.version}\"/' Cargo.toml"
       }
     ],
     [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "dotsnapshot"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dotsnapshot"
 version = "1.4.0"
 edition = "2021"
-rust-version = "1.3.2"
+rust-version = "1.81"
 description = "A CLI utility to create snapshots of dotfiles and configuration for seamless backup and restoration"
 license = "MIT"
 repository = "https://github.com/tomerlichtash/dotsnapshot"
@@ -23,27 +23,27 @@ dirs = "5.0"
 which = "6.0"
 
 [dependencies.tokio]
-version = "1.3.2"
+version = "1.0"
 features = ["full"]
 
 [dependencies.serde]
-version = "1.3.2"
+version = "1.0"
 features = ["derive"]
 
 [dependencies.clap]
-version = "1.3.2"
+version = "4.0"
 features = ["derive", "env", "wrap_help"]
 
 [dependencies.tracing-subscriber]
-version = "1.3.2"
+version = "0.3"
 features = ["local-time"]
 
 [dependencies.time]
-version = "1.3.2"
+version = "0.3"
 features = ["formatting", "local-offset"]
 
 [dependencies.chrono]
-version = "1.3.2"
+version = "0.4"
 features = ["serde"]
 
 [dev-dependencies]


### PR DESCRIPTION
## Problem

The semantic-release is still corrupting ALL version fields in Cargo.toml instead of just the package version. The v1.4.0 release has corrupted rust-version and dependency versions.

## Solution

1. **Fix Cargo.toml**: Restore correct rust-version and dependency versions
2. **Improve semantic-release**: Use more specific sed pattern that only matches the package version within the package section

## Changes

- rust-version = "1.81" (was "1.3.2") 
- All dependency versions restored to correct values
- Updated semantic-release to use targeted pattern matching

## Impact

This will fix the binary build failures in the release workflow by ensuring valid rust-version and dependency versions.