### PR TITLE
fix: Add bash shell specification for Windows packaging steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,7 @@ jobs:
           tar -czf ../../../${{ matrix.asset_name }}.tar.gz ${{ matrix.artifact_name }}
         fi
         cd ../../..
+      shell: bash
 
     - name: Generate checksums
       run: |
@@ -148,6 +149,7 @@ jobs:
         else
           shasum -a 256 ${{ matrix.asset_name }}.tar.gz > ${{ matrix.asset_name }}.sha256
         fi
+      shell: bash
 
     - name: Upload release binary
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem

The Windows binary packaging is failing because bash syntax is being executed in PowerShell on Windows runners. The error is:


## Solution

Added explicit `shell: bash` specification to the packaging and checksum generation steps to ensure bash syntax works correctly on Windows runners.

## Changes

- Added `shell: bash` to "Package binary for distribution" step
- Added `shell: bash` to "Generate checksums" step

## Impact

This will fix the Windows binary packaging failure, allowing the release workflow to create Windows .zip files with checksums successfully.