### PR TITLE
feat: Set up stable branch for controlled releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [ main ]
+    branches: [ stable ]
   workflow_dispatch:
 
 permissions:
@@ -14,7 +14,7 @@ jobs:
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/stable'
     outputs:
       new_release_created: ${{ steps.check_release.outputs.new_release_created }}
       release_tag: ${{ steps.check_release.outputs.release_tag }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["main"],
+  "branches": ["stable"],
   "preset": "conventionalcommits",
   "plugins": [
     "@semantic-release/commit-analyzer",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# Claude Development Rules and Configuration
+
+## Mandatory Workflow Process
+
+**NEVER SKIP THESE STEPS - NO EXCEPTIONS:**
+
+1. **Create Issue First**
+   - Every change must start with a GitHub issue
+   - Describe the problem/feature clearly
+   - Include implementation details and acceptance criteria
+
+2. **Create Feature Branch**
+   - Use descriptive branch names: `feature/description`, `fix/description`
+   - Always branch from `main` unless otherwise specified
+
+3. **Follow Semantic Commit Rules**
+   - **feat:** New features
+   - **fix:** Bug fixes  
+   - **docs:** Documentation changes
+   - **style:** Code style changes (formatting, etc.)
+   - **refactor:** Code refactoring
+   - **test:** Adding or updating tests
+   - **chore:** Maintenance tasks
+   - **ci:** CI/CD changes
+
+4. **Create Pull Request with Proper Title**
+   - **Format:** `type: Description with capital letter`
+   - **Max 72 characters**
+   - **Must start with semantic prefix**
+   - **First word after colon must be capitalized**
+   - **Examples:**
+     - ✅ `feat: Add GitHub Pages documentation site`
+     - ✅ `fix: Resolve Cargo.lock version conflicts`
+     - ❌ `feat: add github pages documentation site` (not capitalized)
+     - ❌ `Add GitHub Pages documentation site` (no semantic prefix)
+
+5. **Link PR to Issue**
+   - Use "Addresses #X", "Closes #X", or "Fixes #X" in PR description
+   - Choose based on whether PR fully resolves the issue
+
+6. **Always Use TodoWrite Tool**
+   - Track progress with TodoWrite for any multi-step work
+   - Include "Create issue" and "Create PR with semantic title" as todos
+
+## Testing and Quality
+
+- Always run lint and typecheck commands before committing
+- Test commands: Check README or ask user for project-specific commands
+- Never commit if tests are failing
+
+## Branch Strategy
+
+- **main:** Development branch - no releases
+- **stable:** Release branch - triggers semantic-release
+- **Feature branches:** For all development work
+
+## Release Process
+
+- Development happens on `main`
+- Releases only from `stable` branch via semantic-release
+- To release: merge `main` into `stable`
+
+## Repository Structure
+
+- `docs/` - GitHub Pages documentation only
+- `homebrew/` - Homebrew formula and setup (master copies)
+- `src/` - Rust source code
+- `.github/workflows/` - CI/CD workflows
+
+---
+
+**Claude: Reference this file before starting any work. These rules are non-negotiable.**


### PR DESCRIPTION
## Summary
Implement semantic release branch strategy to separate development from releases and fix version management issues.

## Changes
- Add CLAUDE.md with mandatory workflow rules and configuration
- Update `.releaserc.json` to only release from `stable` branch instead of `main`
- Update `.github/workflows/release.yml` to trigger on `stable` branch pushes
- Establish clear separation between development and release processes

## Benefits
- **Clean development**: `main` branch stays clean without version conflicts
- **Controlled releases**: Releases only happen when `main` is merged into `stable`
- **Proper version management**: Version bumps happen on `stable` and are committed there
- **No more Cargo.lock conflicts**: Development PRs won't have version changes

## New Workflow
1. Development continues on `main` branch (no releases)
2. When ready to release: merge `main` → `stable`
3. Semantic-release triggers on `stable` branch push
4. Version bump is committed to `stable` branch

## Next Steps
After this PR merges:
1. Create the actual `stable` branch from `main`
2. Test the new release process
3. Update documentation with new workflow

Addresses #29