### PR TITLE
fix: Add cargo check to semantic-release to update Cargo.lock

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -8,7 +8,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "sed -i '/^name = \"dotsnapshot\"/,/^edition = \"2021\"/ s/^version = \".*\"/version = \"${nextRelease.version}\"/' Cargo.toml"
+        "prepareCmd": "sed -i '/^name = \"dotsnapshot\"/,/^edition = \"2021\"/ s/^version = \".*\"/version = \"${nextRelease.version}\"/' Cargo.toml && cargo check"
       }
     ],
     [


### PR DESCRIPTION
## Summary
Fix semantic-release configuration to ensure `Cargo.lock` is properly updated and committed during the release process.

## Problem
Currently, semantic-release:
1. ✅ Updates `Cargo.toml` version via `sed` command
2. ✅ Commits `CHANGELOG.md` and `Cargo.toml`
3. ❌ Leaves `Cargo.lock` uncommitted with version changes

This happens because `Cargo.lock` isn't automatically regenerated when `Cargo.toml` is updated by the `sed` command.

## Solution
Update the `prepareCmd` in `.releaserc.json` to:
- Add `&& cargo check` after the `sed` command
- This regenerates `Cargo.lock` with the new version
- Ensures both files are committed together by `@semantic-release/git`

## Changes
```diff
- "prepareCmd": "sed -i '/^name = \"dotsnapshot\"/,/^edition = \"2021\"/ s/^version = \".*\"/version = \"${nextRelease.version}\"/' Cargo.toml"
+ "prepareCmd": "sed -i '/^name = \"dotsnapshot\"/,/^edition = \"2021\"/ s/^version = \".*\"/version = \"${nextRelease.version}\"/' Cargo.toml && cargo check"
```

## Testing Plan
After merge:
1. Clean up stable branch
2. Trigger a test release by merging main → stable
3. Verify both `Cargo.toml` and `Cargo.lock` are committed with correct versions

Fixes #33