### PR TITLE
fix: Disable crates.io publishing to prevent release failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,21 +167,23 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  publish-crate:
-    name: Publish to crates.io
-    needs: [release, build-release]
-    runs-on: ubuntu-latest
-    if: needs.release.outputs.new_release_created == 'true'
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ needs.release.outputs.release_tag }}
-
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
-
-    - name: Publish to crates.io
-      run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
-      continue-on-error: true
+# Disabled crates.io publishing to prevent release failures
+  # Re-enable when CRATES_IO_TOKEN is configured and crates.io publishing is desired
+  # publish-crate:
+  #   name: Publish to crates.io
+  #   needs: [release, build-release]
+  #   runs-on: ubuntu-latest
+  #   if: needs.release.outputs.new_release_created == 'true'
+  #   
+  #   steps:
+  #   - name: Checkout code
+  #     uses: actions/checkout@v4
+  #     with:
+  #       ref: ${{ needs.release.outputs.release_tag }}
+  #
+  #   - name: Install Rust toolchain
+  #     uses: dtolnay/rust-toolchain@stable
+  #
+  #   - name: Publish to crates.io
+  #     run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
+  #     continue-on-error: true


### PR DESCRIPTION
## Summary
Disable the crates.io publishing step in the release workflow to prevent release failures and ensure reliable releases.

## Problem
The release workflow has been failing because the `publish-crate` job encounters issues such as:
- Missing `CRATES_IO_TOKEN` secret configuration
- Authentication/permission failures with crates.io
- Potential package name conflicts

This causes the entire release process to fail even though:
- GitHub releases are successfully created
- Cross-platform binaries are built and uploaded
- The core release functionality works correctly

## Solution
- Comment out the `publish-crate` job in `.github/workflows/release.yml`
- Add clear comments explaining how to re-enable it
- Focus on GitHub releases and Homebrew as primary distribution methods

## Benefits
- **Reliable releases**: No more failures due to crates.io issues
- **Faster workflow**: Eliminates unnecessary publish step
- **Simpler maintenance**: One less dependency to manage
- **Easy re-enablement**: Can uncomment when needed

## Distribution Strategy
This change aligns with the project's distribution focus:
- ✅ **GitHub releases**: Pre-built binaries for all platforms
- ✅ **Homebrew**: Package management via homebrew-tools tap
- ⏸️ **crates.io**: Disabled until explicitly needed

## Testing
After merge, the next release should complete successfully without crates.io publish failures.

Fixes #35