### PR TITLE
chore: Sync main branch to v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [1.7.0](https://github.com/tomerlichtash/dotsnapshot/compare/v1.6.0...v1.7.0) (2025-07-19)
+
+### Features
+
+* Add GitHub Pages documentation site ([#27](https://github.com/tomerlichtash/dotsnapshot/issues/27)) ([3ff8958](https://github.com/tomerlichtash/dotsnapshot/commit/3ff89582adbc9cedfc0b2130e41ab70b46502bd9))
+
+### Bug Fixes
+
+* Add cargo check to semantic-release to update Cargo.lock ([#34](https://github.com/tomerlichtash/dotsnapshot/issues/34)) ([9118166](https://github.com/tomerlichtash/dotsnapshot/commit/9118166523e4f796a95aac8ae881818bc94860bb))
+
+## [1.6.0](https://github.com/tomerlichtash/dotsnapshot/compare/v1.5.0...v1.6.0) (2025-07-19)
+
+### Features
+
+* Set up stable branch for controlled releases ([#30](https://github.com/tomerlichtash/dotsnapshot/issues/30)) ([9460000](https://github.com/tomerlichtash/dotsnapshot/commit/94600009129a4cde54c2b4ced1a9486e800e34fe))
+
 ## [1.5.0](https://github.com/tomerlichtash/dotsnapshot/compare/v1.4.2...v1.5.0) (2025-07-18)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "dotsnapshot"
-version = "1.5.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dotsnapshot"
-version = "1.5.0"
+version = "1.7.0"
 edition = "2021"
 rust-version = "1.81"
 description = "A CLI utility to create snapshots of dotfiles and configuration for seamless backup and restoration"


### PR DESCRIPTION
## Summary
Fix version inconsistency by manually syncing main branch to match the actual latest release v1.7.0.

## Problem
Version mixup across branches and releases:
- **Main branch**: Cargo.toml = v1.5.0 ❌
- **Stable branch**: Cargo.toml = v1.6.0 ❌
- **Actual latest release**: v1.7.0 ✅

## Changes
- **Cargo.toml**: Version 1.5.0 → 1.7.0
- **Cargo.lock**: Updated to match v1.7.0 dependencies  
- **CHANGELOG.md**: Added complete release history including v1.7.0 and v1.6.0

## Benefits
- Main branch reflects actual latest release
- Consistent version across all components
- Proper foundation for future releases
- Eliminates confusion about current version

## Verification
After merge:
- Main branch version: v1.7.0 ✅
- Latest release: v1.7.0 ✅
- Next step: Sync stable branch to match

Fixes #37