### PR TITLE
feat: Revert to main branch releases with RELEASE keyword [RELEASE]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [ stable ]
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:
@@ -14,7 +14,7 @@ jobs:
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/stable'
+    if: github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'RELEASE')
     outputs:
       new_release_created: ${{ steps.check_release.outputs.new_release_created }}
       release_tag: ${{ steps.check_release.outputs.release_tag }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["stable"],
+  "branches": ["main"],
   "preset": "conventionalcommits",
   "plugins": [
     "@semantic-release/commit-analyzer",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,15 +50,15 @@
 
 ## Branch Strategy
 
-- **main:** Development branch - no releases
-- **stable:** Release branch - triggers semantic-release
+- **main:** Development and release branch
 - **Feature branches:** For all development work
 
 ## Release Process
 
-- Development happens on `main`
-- Releases only from `stable` branch via semantic-release
-- To release: merge `main` into `stable`
+- Development happens on `main` via PRs
+- Releases trigger from `main` when PR title contains **"RELEASE"**
+- Only PRs with "RELEASE" in title will trigger semantic-release
+- Example: `feat: Add new feature [RELEASE]`
 
 ## Repository Structure
 


### PR DESCRIPTION
## Summary
Revert to releasing from main branch with a keyword-based trigger to control when releases happen.

## Problem with Stable Branch Strategy
- Creates constant diff between main and stable branches
- GitHub shows persistent "stable branch had recent pushes" notifications  
- More complex workflow than needed for this project
- Semantic-release commits on stable don't sync back to main

## New Strategy: Controlled Main Branch Releases
- ✅ **Release from `main`** - Back to simple single-branch workflow
- ✅ **RELEASE keyword trigger** - Only PRs with "RELEASE" in title trigger releases
- ✅ **Full control** - Choose exactly when to release
- ✅ **Clean workflow** - No branch synchronization issues

## Changes Made
1. **`.releaserc.json`**: Changed branches from `["stable"]` to `["main"]`
2. **Release workflow**: Updated to trigger on main branch pushes
3. **Added condition**: Only releases when commit message contains "RELEASE"
4. **CLAUDE.md**: Updated with new release strategy

## How It Works Now
- **Normal PRs**: `feat: Add feature` → No release
- **Release PRs**: `feat: Add feature [RELEASE]` → Triggers release
- **Automatic versioning**: Based on conventional commit type (feat/fix/etc)

## Benefits
- 🚀 **Simple workflow** - One branch, clear control
- 🎯 **Selective releases** - Only when you want them
- 🧹 **Clean git history** - No persistent branch differences  
- ⚡ **Fast releases** - No branch merging required

## Testing
This PR itself contains "[RELEASE]" in the title, so merging it will trigger a release to test the new system\!

Addresses #39