### PR TITLE
fix: Sync main branch to actual v1.7.0 release state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,3 @@
-## [1.6.0](https://github.com/tomerlichtash/dotsnapshot/compare/v1.5.0...v1.6.0) (2025-07-19)
-
-### Features
-
-* Add GitHub Pages documentation site ([#27](https://github.com/tomerlichtash/dotsnapshot/issues/27)) ([3ff8958](https://github.com/tomerlichtash/dotsnapshot/commit/3ff89582adbc9cedfc0b2130e41ab70b46502bd9))
-* Revert to main branch releases with RELEASE keyword [RELEASE] ([#40](https://github.com/tomerlichtash/dotsnapshot/issues/40)) ([b3a89af](https://github.com/tomerlichtash/dotsnapshot/commit/b3a89af9b33658da6a9e080fe15828a614bcc6d9))
-* Set up stable branch for controlled releases ([#30](https://github.com/tomerlichtash/dotsnapshot/issues/30)) ([9460000](https://github.com/tomerlichtash/dotsnapshot/commit/94600009129a4cde54c2b4ced1a9486e800e34fe))
-
-### Bug Fixes
-
-* Add cargo check to semantic-release to update Cargo.lock ([#34](https://github.com/tomerlichtash/dotsnapshot/issues/34)) ([9118166](https://github.com/tomerlichtash/dotsnapshot/commit/9118166523e4f796a95aac8ae881818bc94860bb))
-
 ## [1.7.0](https://github.com/tomerlichtash/dotsnapshot/compare/v1.6.0...v1.7.0) (2025-07-19)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "dotsnapshot"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dotsnapshot"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 rust-version = "1.81"
 description = "A CLI utility to create snapshots of dotfiles and configuration for seamless backup and restoration"


### PR DESCRIPTION
## Summary
Clean up version inconsistencies and sync main branch to match the actual v1.7.0 release.

## Problems Fixed
- **Cargo.toml**: 1.6.0 → 1.7.0 ✅
- **Cargo.lock**: Updated to v1.7.0 dependencies ✅
- **CHANGELOG.md**: Fixed malformed chronology, proper order from v1.7.0 tag ✅

## Root Cause
During the stable→main branch strategy changes, version sync got corrupted and main branch didn't reflect the actual latest release (v1.7.0).

## Solution Applied
Restored files from the actual v1.7.0 git tag to ensure consistency:
```bash
git show v1.7.0:Cargo.toml > Cargo.toml
git show v1.7.0:Cargo.lock > Cargo.lock  
git show v1.7.0:CHANGELOG.md > CHANGELOG.md
```

## Expected Results After Merge
- ✅ Main branch version matches latest release (v1.7.0)
- ✅ Clean foundation for future releases with RELEASE keyword
- ✅ Working release workflow
- ✅ Consistent version across all components

## Note
This PR intentionally does NOT include "[RELEASE]" since we're just fixing existing state, not releasing new features.

Fixes #41