### PR TITLE
fix: Clear GH_TOKEN before gh auth in publishCmd

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,7 +9,7 @@
       "@semantic-release/exec",
       {
         "prepareCmd": "sed -i '/^name = \"dotsnapshot\"/,/^edition = \"2021\"/ s/^version = \".*\"/version = \"${nextRelease.version}\"/' Cargo.toml && cargo check",
-        "publishCmd": "git config --global user.name 'github-actions[bot]' && git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com' && git checkout -b release/v${nextRelease.version} && git add CHANGELOG.md Cargo.toml Cargo.lock && git commit -m 'chore(release): ${nextRelease.version} [skip ci]' && git push origin release/v${nextRelease.version} && gh pr create --title 'chore(release): ${nextRelease.version} [RELEASE]' --body 'Automated release PR for version ${nextRelease.version}\\n\\n${nextRelease.notes}' --base main --head release/v${nextRelease.version} && gh pr merge --squash --auto"
+        "publishCmd": "git config --global user.name 'github-actions[bot]' && git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com' && git checkout -b release/v${nextRelease.version} && git add CHANGELOG.md Cargo.toml Cargo.lock && git commit -m 'chore(release): ${nextRelease.version} [skip ci]' && git push origin release/v${nextRelease.version} && unset GH_TOKEN && echo \"$GITHUB_TOKEN\" | gh auth login --with-token && gh pr create --title 'chore(release): ${nextRelease.version} [RELEASE]' --body 'Automated release PR for version ${nextRelease.version}\\n\\n${nextRelease.notes}' --base main --head release/v${nextRelease.version} && gh pr merge --squash --auto"
       }
     ],
     [


### PR DESCRIPTION
Fixes GitHub CLI authentication conflict by unsetting GH_TOKEN environment variable before manual authentication in semantic-release publishCmd.

🤖 Generated with [Claude Code](https://claude.ai/code)