### PR TITLE
fix: Bump v1.7.1 to resolve tagging conflict [RELEASE]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dotsnapshot"
-version = "1.7.0"
+version = "1.7.1"
 edition = "2021"
 rust-version = "1.81"
 description = "A CLI utility to create snapshots of dotfiles and configuration for seamless backup and restoration"


### PR DESCRIPTION
Fixes version mismatch where semantic-release was trying to create v1.6.0 tag but v1.7.0 already exists.

🤖 Generated with [Claude Code](https://claude.ai/code)