### PR TITLE
fix: Reset semantic-release by deleting conflicting tags [RELEASE]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dotsnapshot"
-version = "1.7.1"
+version = "1.6.0"
 edition = "2021"
 rust-version = "1.81"
 description = "A CLI utility to create snapshots of dotfiles and configuration for seamless backup and restoration"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dotsnapshot"
-version = "1.6.0"
+version = "1.8.0"
 edition = "2021"
 rust-version = "1.81"
 description = "A CLI utility to create snapshots of dotfiles and configuration for seamless backup and restoration"


### PR DESCRIPTION
Resets semantic-release state by:
- Deleting problematic v1.6.0 and v1.7.0 tags that were causing conflicts
- Aligning Cargo.toml version to 1.6.0 to match what semantic-release expects

This will allow semantic-release to properly create v1.6.0 and then continue forward.

🤖 Generated with [Claude Code](https://claude.ai/code)