### PR TITLE
fix: Reset all versions to 1.0.0 and delete all tags/releases [RELEASE]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "dotsnapshot"
-version = "1.7.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dotsnapshot"
-version = "1.8.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.81"
 description = "A CLI utility to create snapshots of dotfiles and configuration for seamless backup and restoration"


### PR DESCRIPTION
Complete reset of semantic-release state:

- Reset Cargo.toml version to 1.0.0
- Deleted all version tags locally and remotely  
- Deleted all GitHub releases
- Clean slate for semantic-release to start from 1.0.0

This should resolve all version conflicts and allow semantic-release to work properly.

🤖 Generated with [Claude Code](https://claude.ai/code)