### PR TITLE
feat: Implement simplified branch-based release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 
 on:
-  push:
-    branches: [ main ]
+  pull_request:
+    types: [closed]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -12,79 +13,82 @@ permissions:
 
 jobs:
   release:
-    name: Semantic Release
+    name: Branch-Based Release
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'RELEASE')
+    if: |
+      github.event.pull_request.merged == true && 
+      startsWith(github.head_ref, 'release/v')
     outputs:
-      new_release_created: ${{ steps.check_release.outputs.new_release_created }}
-      release_tag: ${{ steps.check_release.outputs.release_tag }}
-      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
-      new_release_version: ${{ steps.semantic.outputs.new_release_version }}
+      new_release_created: "true"
+      release_tag: ${{ steps.version.outputs.tag }}
+      new_release_published: "true"
+      new_release_version: ${{ steps.version.outputs.version }}
     
     steps:
+    - name: Extract version from branch name
+      id: version
+      run: |
+        # release/v1.3.0 → 1.3.0
+        VERSION=$(echo ${{ github.head_ref }} | sed 's/release\/v//')
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+        echo "Extracted version: $VERSION"
+        
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-
-    - name: Install semantic-release
-      run: |
-        npm install -g semantic-release
-        npm install -g @semantic-release/changelog
-        npm install -g @semantic-release/git
-        npm install -g @semantic-release/github
-        npm install -g @semantic-release/exec
-        npm install -g conventional-changelog-conventionalcommits
-
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
 
-    - name: Run semantic release
-      id: semantic
-      run: npx semantic-release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
-    - name: Check if release was created
-      id: check_release
+    - name: Update version for release (temporary)
       run: |
-        # Get the latest release and check if it was created in the last minute
-        LATEST_RELEASE=$(gh release list --limit 1 --json createdAt,tagName | jq -r '.[0]')
-        CREATED_AT=$(echo $LATEST_RELEASE | jq -r '.createdAt')
-        TAG_NAME=$(echo $LATEST_RELEASE | jq -r '.tagName')
+        # Update version temporarily for this build only
+        sed -i "s/version = \".*\"/version = \"${{ steps.version.outputs.version }}\"/" Cargo.toml
+        cargo update --package dotsnapshot --precise "${{ steps.version.outputs.version }}"
         
-        # Check if release was created in the last 2 minutes
-        if [ -n "$CREATED_AT" ] && [ "$CREATED_AT" != "null" ]; then
-          CREATED_TIMESTAMP=$(date -d "$CREATED_AT" +%s)
-          CURRENT_TIMESTAMP=$(date +%s)
-          DIFF=$((CURRENT_TIMESTAMP - CREATED_TIMESTAMP))
-          
-          if [ $DIFF -lt 120 ]; then
-            echo "new_release_created=true" >> $GITHUB_OUTPUT
-            echo "release_tag=$TAG_NAME" >> $GITHUB_OUTPUT
-            echo "Recent release found: $TAG_NAME"
-          else
-            echo "new_release_created=false" >> $GITHUB_OUTPUT
-            echo "No recent release found"
-          fi
-        else
-          echo "new_release_created=false" >> $GITHUB_OUTPUT
-          echo "No release found"
+    - name: Build release binary
+      run: |
+        cargo build --release
+        
+    - name: Verify binary version
+      run: |
+        BINARY_VERSION=$(target/release/dotsnapshot --version | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
+        if [ "$BINARY_VERSION" != "${{ steps.version.outputs.version }}" ]; then
+          echo "❌ Version mismatch: binary reports $BINARY_VERSION, expected ${{ steps.version.outputs.version }}"
+          exit 1
         fi
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        echo "✅ Binary version verified: $BINARY_VERSION"
+        
+    - name: Generate release notes
+      run: |
+        LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+        if [ -n "$LAST_TAG" ]; then
+          echo "# Release v${{ steps.version.outputs.version }}" > RELEASE_NOTES.md
+          echo "" >> RELEASE_NOTES.md
+          git log --oneline "${LAST_TAG}..HEAD" --pretty=format:"- %s" >> RELEASE_NOTES.md
+        else
+          echo "# Release v${{ steps.version.outputs.version }}" > RELEASE_NOTES.md
+          echo "" >> RELEASE_NOTES.md
+          echo "Initial release" >> RELEASE_NOTES.md
+        fi
+        
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ steps.version.outputs.tag }}
+        name: Release ${{ steps.version.outputs.tag }}
+        body_path: RELEASE_NOTES.md
+        draft: false
+        prerelease: false
 
   build-release:
     name: Build Release Binaries
     runs-on: ${{ matrix.os }}
     needs: release
-    if: needs.release.outputs.new_release_created == 'true'
+    if: always() && needs.release.result == 'success'
     
     strategy:
       matrix:
@@ -116,6 +120,12 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         targets: ${{ matrix.target }}
+
+    - name: Update version for release
+      run: |
+        # Update version to match the release
+        sed -i "s/version = \".*\"/version = \"${{ needs.release.outputs.new_release_version }}\"/" Cargo.toml
+        cargo update --package dotsnapshot --precise "${{ needs.release.outputs.new_release_version }}"
 
     - name: Cache Cargo dependencies
       uses: actions/cache@v4
@@ -171,7 +181,7 @@ jobs:
     name: Update main branch version after release
     needs: [release, build-release]
     runs-on: ubuntu-latest
-    if: needs.release.outputs.new_release_created == 'true'
+    if: always() && needs.release.result == 'success' && needs.build-release.result == 'success'
     
     steps:
     - name: Checkout main branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,10 +55,35 @@
 
 ## Release Process
 
-- Development happens on `main` via PRs
-- Releases trigger from `main` when PR title contains **"RELEASE"**
-- Only PRs with "RELEASE" in title will trigger semantic-release
-- Example: `feat: Add new feature [RELEASE]`
+**Simplified Branch-Based Release Workflow:**
+
+1. **Use Release Script (Recommended)**
+   ```bash
+   ./scripts/release.sh 1.3.0
+   ```
+   
+   This script automatically:
+   - Creates `release/v1.3.0` branch
+   - Updates version in Cargo.toml
+   - Builds and tests the release
+   - Creates PR with release notes
+   - When PR is merged → automatic release
+
+2. **Manual Process (Alternative)**
+   ```bash
+   # 1. Create release branch
+   git checkout main && git pull origin main
+   git checkout -b release/v1.3.0
+   
+   # 2. Update version and create PR
+   # (Release workflow triggers when release/v* branch is merged to main)
+   ```
+
+**Key Changes:**
+- ✅ **No "[RELEASE]" keyword required**
+- ✅ **Branch name triggers release**: `release/v1.3.0` → version 1.3.0
+- ✅ **Automatic version verification** in CI
+- ✅ **Clean, predictable process**
 
 ## Repository Structure
 

--- a/RELEASE_PLAN.md
+++ b/RELEASE_PLAN.md
@@ -1,0 +1,372 @@
+# Release Plan
+
+## Current State Analysis (2025-07-19)
+
+### Version Status Across All Locations
+
+| Location | Version | Status | Notes |
+|----------|---------|--------|-------|
+| **Cargo.toml** | `1.2.1` | ✅ Correct | Updated by recent PRs |
+| **Latest GitHub Release** | `v1.2.1` | ✅ Correct | Created successfully |
+| **Binary (v1.2.1 release)** | `1.2.1` | ✅ Correct | Finally reports correct version! |
+| **Git Tags** | `v1.0.0, v1.1.0, v1.2.0, v1.2.1` | ✅ Correct | All tags properly set |
+| **Main Branch HEAD** | `5539555` | ❌ Messy | Multiple release commits |
+
+### What Actually Worked 
+
+**🎉 SUCCESS: v1.2.1 is now correctly released!**
+
+- ✅ **GitHub Release**: v1.2.1 exists and has binaries
+- ✅ **Binary Version**: `dotsnapshot --version` reports "dotsnapshot v1.2.1" 
+- ✅ **Cargo.toml**: Version is correctly set to "1.2.1"
+- ✅ **Git Tags**: All tags (v1.0.0 through v1.2.1) are properly set
+
+### Repository Cleanup Needed
+
+**Branch Pollution**: 15+ experimental release branches exist:
+```
+release/v1.2.0, release/v1.2.1, release/v1.2.1-fix
+test/auto-release-workflow, test/first-release, test/release-pr-workflow
+fix/semantic-release-pr-workflow, feat/semantic-release
+...and more
+```
+
+**Main Branch History**: Multiple redundant release commits:
+```
+5539555 fix: Trigger v1.2.1 release with correct binary version [RELEASE]
+674fcf5 chore: Release version 1.2.1 with correct binary version [RELEASE] (#60)  
+4de334b chore: Release version 1.2.0 [RELEASE] (#59)
+```
+
+### Problems with Current Semantic Release Approach
+
+1. ~~**Version Mismatch**: Binary reports wrong version (1.0.0 vs 1.2.1)~~ ✅ **FIXED**
+2. **Commit Type Confusion**: `chore:` doesn't trigger releases, only `feat:` and `fix:`
+3. **Branch Pollution**: Too many experimental branches
+4. **Complex Flow**: Too many moving parts, hard to debug
+5. **Messy History**: Multiple release commits for same version
+
+## Cleanup Strategy (Before New Release Process)
+
+### Step 1: Clean Up Branches
+```bash
+# Delete all experimental release branches (both local and remote)
+git branch -D $(git branch | grep -E "(release/|test/|fix/.*release|feat/.*release)" | tr -d ' ')
+
+# Delete remote branches (carefully!)
+git push origin --delete release/v1.2.0
+git push origin --delete release/v1.2.1  
+git push origin --delete release/v1.2.1-fix
+git push origin --delete test/auto-release-workflow
+git push origin --delete test/first-release
+git push origin --delete test/release-pr-workflow
+git push origin --delete test/release-workflow
+git push origin --delete test/trigger-new-release
+git push origin --delete fix/semantic-release-pr-workflow
+git push origin --delete feat/semantic-release
+# ... (and other experimental branches)
+```
+
+### Step 2: Prepare Main Branch for Next Development
+```bash
+# Current state: Cargo.toml = "1.2.1" (matches released version)
+# Next development version should be "1.2.2"
+
+git checkout main
+git pull origin main
+
+# Update to next development version
+sed -i 's/version = "1.2.1"/version = "1.2.2"/' Cargo.toml
+cargo update --package dotsnapshot --precise "1.2.2"
+
+# Commit development version
+git add Cargo.toml Cargo.lock  
+git commit -m "chore: Bump to v1.2.2 for next development cycle"
+git push origin main
+```
+
+### Step 3: Verify Clean State
+After cleanup, verify:
+- ✅ **Main branch**: Cargo.toml shows "1.2.2" (next dev version)
+- ✅ **Latest release**: v1.2.1 with correct binary version  
+- ✅ **Tags**: All release tags (v1.0.0 through v1.2.1) exist
+- ✅ **Branches**: Only main + active feature branches remain
+
+## Requirements
+
+✅ **Version Alignment**: Release tag = Cargo.toml version = binary --version output  
+✅ **No Uncommitted Changes**: Clean state after release  
+✅ **No Direct Main Pushes**: All changes via PRs  
+✅ **Automated & Reproducible**: Clear, reliable process  
+✅ **Controlled Releases**: Manual trigger, not every merge  
+✅ **Clear Changelog**: Automated generation  
+
+## Proposed Solution: Branch-Based Release Workflow
+
+### Core Principle
+**Branch Name as Trigger**: `release/v1.3.0` branch automatically triggers release of version 1.3.0.
+
+### Release Process
+
+#### 1. Development Phase
+- All development happens on feature branches
+- PRs merge to main with standard commit messages
+- Cargo.toml stays at current development version (e.g., "1.2.2")
+
+#### 2. Release Trigger (Automated Script)
+```bash
+# Simple one-command release
+./scripts/release.sh 1.3.0
+
+# This script automatically:
+# 1. Creates branch: release/v1.3.0
+# 2. Adds release notes
+# 3. Creates PR: "Release v1.3.0"
+# 4. When merged → automatic release
+```
+
+#### 3. Release Script Implementation
+```bash
+#!/bin/bash
+# scripts/release.sh
+
+VERSION=$1
+BRANCH="release/v$VERSION"
+
+echo "🚀 Creating release branch: $BRANCH"
+
+git checkout main
+git pull origin main
+git checkout -b "$BRANCH"
+
+# Generate release notes
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [ -n "$LAST_TAG" ]; then
+    echo "# Release v$VERSION" > RELEASE_NOTES.md
+    echo "" >> RELEASE_NOTES.md
+    git log --oneline "${LAST_TAG}..HEAD" --pretty=format:"- %s" >> RELEASE_NOTES.md
+else
+    echo "# Release v$VERSION" > RELEASE_NOTES.md
+    echo "Initial release" >> RELEASE_NOTES.md
+fi
+
+git add RELEASE_NOTES.md
+git commit -m "Prepare release v$VERSION"
+git push origin "$BRANCH"
+
+gh pr create \
+  --title "Release v$VERSION" \
+  --body "🚀 Release version $VERSION
+
+## Changes
+$(cat RELEASE_NOTES.md | tail -n +3)
+
+**Merge this PR to trigger automatic release workflow.**"
+
+echo "✅ Release PR created. Merge to trigger automatic release."
+```
+
+#### 4. Release Workflow (Automated)
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  release:
+    if: |
+      github.event.pull_request.merged == true && 
+      startsWith(github.head_ref, 'release/v')
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Extract version from branch name
+        id: version
+        run: |
+          # release/v1.3.0 → 1.3.0
+          VERSION=$(echo ${{ github.head_ref }} | sed 's/release\/v//')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Update version for release (temporary)
+        run: |
+          # Update version temporarily for this build only
+          sed -i "s/version = \".*\"/version = \"${{ steps.version.outputs.version }}\"/" Cargo.toml
+          cargo update --package dotsnapshot --precise "${{ steps.version.outputs.version }}"
+          
+      - name: Build release binaries
+        run: |
+          # Install Rust
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source ~/.cargo/env
+          
+          # Build for multiple targets
+          cargo build --release
+          
+      - name: Verify binary version
+        run: |
+          BINARY_VERSION=$(target/release/dotsnapshot --version | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
+          if [ "$BINARY_VERSION" != "${{ steps.version.outputs.version }}" ]; then
+            echo "❌ Version mismatch: binary reports $BINARY_VERSION, expected ${{ steps.version.outputs.version }}"
+            exit 1
+          fi
+          echo "✅ Binary version verified: $BINARY_VERSION"
+          
+      - name: Package binaries
+        run: |
+          # Package for distribution
+          tar -czf dotsnapshot-linux-x86_64.tar.gz -C target/release dotsnapshot
+          shasum -a 256 dotsnapshot-linux-x86_64.tar.gz > dotsnapshot-linux-x86_64.sha256
+          
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: Release v${{ steps.version.outputs.version }}
+          body_path: RELEASE_NOTES.md
+          files: |
+            dotsnapshot-*.tar.gz
+            dotsnapshot-*.sha256
+            
+      - name: Prepare next development version
+        run: |
+          # Increment patch version for next development
+          IFS='.' read -r major minor patch <<< "${{ steps.version.outputs.version }}"
+          NEXT_VERSION="$major.$minor.$((patch + 1))"
+          
+          # Create PR to bump main to next dev version
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          
+          git checkout main
+          git pull origin main
+          git checkout -b "chore/bump-to-v$NEXT_VERSION"
+          
+          sed -i "s/version = \".*\"/version = \"$NEXT_VERSION\"/" Cargo.toml
+          cargo update --package dotsnapshot --precise "$NEXT_VERSION"
+          
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore: Bump to v$NEXT_VERSION for next development cycle"
+          git push origin "chore/bump-to-v$NEXT_VERSION"
+          
+          gh pr create \
+            --title "chore: Bump to v$NEXT_VERSION" \
+            --body "Automated version bump after v${{ steps.version.outputs.version }} release" \
+            --auto-merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Alternative: Simplified Manual Process
+
+If the above is still too complex, here's a simpler approach:
+
+#### Manual Release Script
+```bash
+#!/bin/bash
+# scripts/release.sh
+
+set -e
+
+if [ -z "$1" ]; then
+  echo "Usage: ./scripts/release.sh <version>"
+  echo "Example: ./scripts/release.sh 1.3.0"
+  exit 1
+fi
+
+VERSION=$1
+echo "🚀 Releasing version $VERSION"
+
+# 1. Update version
+echo "📝 Updating Cargo.toml to version $VERSION"
+sed -i "s/version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+cargo update --package dotsnapshot --precise "$VERSION"
+
+# 2. Build and test
+echo "🔨 Building and testing"
+cargo build --release
+cargo test
+
+# 3. Verify version
+echo "✅ Verifying binary version"
+BINARY_VERSION=$(target/release/dotsnapshot --version | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
+if [ "$BINARY_VERSION" != "$VERSION" ]; then
+  echo "❌ Version mismatch: binary reports $BINARY_VERSION, expected $VERSION"
+  exit 1
+fi
+
+# 4. Create release commit
+echo "📝 Creating release commit"
+git add Cargo.toml Cargo.lock
+git commit -m "chore: Release v$VERSION"
+
+# 5. Create tag
+echo "🏷️  Creating tag v$VERSION"
+git tag "v$VERSION"
+
+# 6. Push
+echo "⬆️  Pushing to GitHub"
+git push origin main
+git push origin "v$VERSION"
+
+# 7. Create GitHub release (manual)
+echo "🎉 Release v$VERSION created!"
+echo "📋 Create GitHub release at: https://github.com/tomerlichtash/dotsnapshot/releases/new?tag=v$VERSION"
+
+# 8. Prepare next version
+echo "🔄 Preparing next development version"
+IFS='.' read -r major minor patch <<< "$VERSION"
+NEXT_VERSION="$major.$minor.$((patch + 1))"
+
+sed -i "s/version = \".*\"/version = \"$NEXT_VERSION\"/" Cargo.toml
+cargo update --package dotsnapshot --precise "$NEXT_VERSION"
+
+git add Cargo.toml Cargo.lock
+git commit -m "chore: Bump to v$NEXT_VERSION for next development cycle"
+git push origin main
+
+echo "✅ Ready for next development cycle at v$NEXT_VERSION"
+```
+
+## Recommended Approach
+
+**Option 1: Simplified Manual Process**
+- Use the release script above
+- Maintainer runs `./scripts/release.sh 1.3.0`
+- Script handles everything: version bump, build, test, tag, push
+- No complex workflows, easy to debug
+- Clear, predictable process
+
+**Benefits:**
+- ✅ Single source of truth (Cargo.toml)
+- ✅ No uncommitted changes
+- ✅ No direct main pushes (script can be modified to use PRs)
+- ✅ Version alignment guaranteed
+- ✅ Simple to understand and debug
+
+**Next Steps:**
+1. Abandon semantic-release complexity
+2. Implement the manual release script
+3. Test with v1.2.1 release
+4. Document the process
+5. Update Homebrew formula
+
+## Testing the New Process
+
+Let's test with v1.2.1:
+```bash
+# Fix current state
+git checkout main
+git reset --hard HEAD~1  # Remove problematic commits
+echo '1.2.1' > VERSION_TO_RELEASE
+./scripts/release.sh 1.2.1
+```
+
+This gives us a clean, predictable, debuggable release process that meets all requirements.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# Release script for dotsnapshot
+# Usage: ./scripts/release.sh <version>
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${BLUE}ℹ️  $1${NC}"
+}
+
+log_success() {
+    echo -e "${GREEN}✅ $1${NC}"
+}
+
+log_warning() {
+    echo -e "${YELLOW}⚠️  $1${NC}"
+}
+
+log_error() {
+    echo -e "${RED}❌ $1${NC}"
+}
+
+if [ -z "$1" ]; then
+  log_error "Usage: ./scripts/release.sh <version>"
+  log_info "Example: ./scripts/release.sh 1.3.0"
+  exit 1
+fi
+
+VERSION=$1
+log_info "Starting release process for version $VERSION"
+
+# Verify we're on main branch
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+    log_error "Must be on main branch. Currently on: $CURRENT_BRANCH"
+    exit 1
+fi
+
+# Verify clean working directory
+if [ -n "$(git status --porcelain)" ]; then
+    log_error "Working directory must be clean. Please commit or stash changes."
+    git status
+    exit 1
+fi
+
+# Pull latest changes
+log_info "Pulling latest changes from origin/main"
+git pull origin main
+
+# 1. Update version in Cargo.toml
+log_info "Updating Cargo.toml to version $VERSION"
+sed -i '' "s/version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+
+# Update Cargo.lock
+log_info "Updating Cargo.lock"
+cargo update --package dotsnapshot --precise "$VERSION"
+
+# 2. Build and test
+log_info "Building release binary"
+cargo build --release
+
+log_info "Running tests"
+cargo test
+
+# 3. Verify version matches
+log_info "Verifying binary version"
+BINARY_VERSION=$(target/release/dotsnapshot --version | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
+if [ "$BINARY_VERSION" != "$VERSION" ]; then
+  log_error "Version mismatch: binary reports $BINARY_VERSION, expected $VERSION"
+  exit 1
+fi
+log_success "Binary version verified: $BINARY_VERSION"
+
+# 4. Generate changelog for this release
+log_info "Generating release notes"
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [ -n "$LAST_TAG" ]; then
+    log_info "Generating changelog since $LAST_TAG"
+    echo "# Release v$VERSION" > RELEASE_NOTES_TEMP.md
+    echo "" >> RELEASE_NOTES_TEMP.md
+    git log --oneline "${LAST_TAG}..HEAD" --pretty=format:"- %s" >> RELEASE_NOTES_TEMP.md
+    echo "" >> RELEASE_NOTES_TEMP.md
+else
+    log_warning "No previous tags found, creating initial release notes"
+    echo "# Release v$VERSION" > RELEASE_NOTES_TEMP.md
+    echo "" >> RELEASE_NOTES_TEMP.md
+    echo "Initial release" >> RELEASE_NOTES_TEMP.md
+fi
+
+# 5. Create release branch and PR (no direct main pushes)
+RELEASE_BRANCH="release/v$VERSION"
+log_info "Creating release branch: $RELEASE_BRANCH"
+git checkout -b "$RELEASE_BRANCH"
+
+# Commit version changes
+git add Cargo.toml Cargo.lock
+git commit -m "chore: Release v$VERSION
+
+Updates version to $VERSION for release"
+
+# Add release notes if they exist
+if [ -f "RELEASE_NOTES_TEMP.md" ]; then
+    mv RELEASE_NOTES_TEMP.md "RELEASE_NOTES_v$VERSION.md"
+    git add "RELEASE_NOTES_v$VERSION.md"
+    git commit -m "docs: Add release notes for v$VERSION"
+fi
+
+# Push release branch
+log_info "Pushing release branch to origin"
+git push origin "$RELEASE_BRANCH"
+
+# Create PR
+log_info "Creating release PR"
+PR_URL=$(gh pr create \
+    --title "Release v$VERSION" \
+    --body "🚀 Release version $VERSION
+
+## Changes
+$(cat RELEASE_NOTES_v$VERSION.md | tail -n +3)
+
+## Checklist
+- [x] Version updated in Cargo.toml
+- [x] Cargo.lock updated
+- [x] Binary version verified
+- [x] Tests passing
+- [x] Release notes generated
+
+**⚠️ This PR will trigger the release workflow when merged.**" \
+    --label "release")
+
+log_success "Release PR created: $PR_URL"
+
+# Switch back to main
+git checkout main
+
+log_info "Release process initiated!"
+log_info "Next steps:"
+log_info "1. Review the PR: $PR_URL"
+log_info "2. Merge the PR to trigger release workflow"
+log_info "3. GitHub will create the release and build binaries"
+log_info "4. Update Homebrew formula to point to v$VERSION"
+
+log_success "Release v$VERSION ready for review!"


### PR DESCRIPTION
🚀 **Replaces complex semantic-release with clean branch-based approach**

## Summary
- ✅ **No "[RELEASE]" keyword required** - eliminates confusion
- ✅ **Branch name triggers release**: `release/v1.3.0` → version 1.3.0  
- ✅ **One-command releases**: `./scripts/release.sh 1.3.0`
- ✅ **Version alignment guaranteed**: Binary version verified in CI
- ✅ **Predictable, debuggable process**

## Key Changes

### 1. Updated Release Workflow (`.github/workflows/release.yml`)
- **Trigger**: PR merge with `release/v*` branch pattern
- **Version extraction**: `release/v1.3.0` → `1.3.0`
- **Direct GitHub release creation** (no semantic-release dependency)
- **Multi-platform binary building** with version verification

### 2. Automated Release Script (`scripts/release.sh`)
- **Usage**: `./scripts/release.sh 1.3.0`
- **Automates**: branch creation, version update, testing, PR creation
- **Includes**: release notes generation, version verification
- **Safe**: checks clean working directory, runs tests

### 3. Updated Documentation
- **CLAUDE.md**: New simplified process for developers
- **RELEASE_PLAN.md**: Complete analysis and cleanup strategy

## Benefits Over Previous Approach
- ❌ **No more semantic-release complexity**
- ❌ **No more version mismatches**
- ❌ **No more commit type confusion** (chore vs feat vs fix)
- ❌ **No more experimental branch pollution**
- ✅ **Single source of truth for versioning**
- ✅ **Clear, reliable release process**

## Testing Plan
After this PR is merged:
1. Test with `./scripts/release.sh 1.2.2`
2. Verify automatic release creation
3. Update Homebrew formula to new version

## Breaking Changes
- **Replaces**: `[RELEASE]` keyword trigger system
- **New requirement**: Use `release/v*` branch pattern for releases

Addresses ongoing release complexity issues and provides foundation for reliable releases going forward.