### PR TITLE
fix: Prevent release script from corrupting dependency versions

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -56,7 +56,7 @@ git pull origin main
 
 # 1. Update version in Cargo.toml
 log_info "Updating Cargo.toml to version $VERSION"
-sed -i '' "s/version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+sed -i '' '/^\[package\]/,/^\[/ s/^version = ".*"/version = "'$VERSION'"/' Cargo.toml
 
 # Update Cargo.lock
 log_info "Updating Cargo.lock"


### PR DESCRIPTION
🐛 Fixes critical bug in release.sh script

## Problem
The release script was corrupting Cargo.toml by updating ALL version lines, not just the package version. This caused dependency versions to be overwritten with the release version.

## Root Cause
Previous sed pattern matched both package and dependency versions:
- Package version (correct): version = "1.2.1"  
- Dependency versions (wrong): version = "1.0"

## Solution
New range-based sed pattern only operates within [package] section:
- Stops at next section starting with [
- Only updates package version, leaves dependencies untouched

## Impact
- Fixes corrupted Cargo.toml during releases
- Prevents build failures due to invalid dependency versions
- Ensures clean, reliable release process