### PR TITLE
Release v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.2.2] - 2025-07-20
+
+- fix: Exclude release PRs from semantic commit validation (#65)
+- fix: Prevent release script from corrupting dependency versions (#63)
+- feat: Implement simplified branch-based release workflow (#62)
+
 ## [1.7.0](https://github.com/tomerlichtash/dotsnapshot/compare/v1.6.0...v1.7.0) (2025-07-19)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "dotsnapshot"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dotsnapshot"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 rust-version = "1.81"
 description = "A CLI utility to create snapshots of dotfiles and configuration for seamless backup and restoration"


### PR DESCRIPTION
🚀 Release version 1.2.2

## Changes
- fix: Exclude release PRs from semantic commit validation (#65)
- fix: Prevent release script from corrupting dependency versions (#63)
- feat: Implement simplified branch-based release workflow (#62)

## Checklist
- [x] Version updated in Cargo.toml
- [x] Cargo.lock updated
- [x] CHANGELOG.md updated
- [x] Binary version verified
- [x] Tests passing

**⚠️ This PR will trigger the release workflow when merged.**