### PR TITLE
Release v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [1.2.2] - 2025-07-20
 
+- fix: Prevent sed from matching rust-version field (#67)
+- Release v1.2.2 (#66)
+- fix: Exclude release PRs from semantic commit validation (#65)
+- fix: Prevent release script from corrupting dependency versions (#63)
+- feat: Implement simplified branch-based release workflow (#62)
+
+## [1.2.2] - 2025-07-20
+
 - fix: Exclude release PRs from semantic commit validation (#65)
 - fix: Prevent release script from corrupting dependency versions (#63)
 - feat: Implement simplified branch-based release workflow (#62)


### PR DESCRIPTION
🚀 Release version 1.2.2

## Changes
- fix: Prevent sed from matching rust-version field (#67)
- Release v1.2.2 (#66)
- fix: Exclude release PRs from semantic commit validation (#65)
- fix: Prevent release script from corrupting dependency versions (#63)
- feat: Implement simplified branch-based release workflow (#62)

## Checklist
- [x] Version updated in Cargo.toml
- [x] Cargo.lock updated
- [x] CHANGELOG.md updated
- [x] Binary version verified
- [x] Tests passing

**⚠️ This PR will trigger the release workflow when merged.**