### PR TITLE
feat: Temporarily disable Windows builds in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,8 @@ jobs:
           - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, use-cross: true }
           - { os: macos-latest, target: x86_64-apple-darwin, use-cross: false }
           - { os: macos-latest, target: aarch64-apple-darwin, use-cross: false }
-          - { os: windows-latest, target: x86_64-pc-windows-msvc, use-cross: false }
+          # Temporarily disabled Windows builds during semantic-release implementation
+          # - { os: windows-latest, target: x86_64-pc-windows-msvc, use-cross: false }
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Temporarily disable Windows binary compilation in the release workflow during semantic-release implementation to simplify initial testing and validation.

## Changes

- Comment out Windows build matrix job in 
- Reduces build complexity during semantic-release workflow testing
- Windows builds will be re-enabled once continuous releases are verified

## Why This Change

This allows us to:
- Focus on Linux and macOS builds initially
- Reduce CI time and complexity during testing
- Validate semantic-release workflow without Windows-specific issues
- Re-enable Windows builds after successful validation

## Test Plan

- [ ] Verify workflow runs successfully with Linux and macOS builds only
- [ ] Confirm semantic-release creates proper releases
- [ ] Validate binary artifacts are generated correctly
- [ ] Re-enable Windows builds in follow-up PR

🤖 Generated with [Claude Code](https://claude.ai/code)