### PR TITLE
fix: Target only package version in Cargo.toml updates

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -17,7 +17,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "sed -i.bak 's/^version = \"[^\"]*\"/version = \"${nextRelease.version}\"/' Cargo.toml && cargo update --package dotsnapshot --precise \"${nextRelease.version}\""
+        "prepareCmd": "sed -i.bak '/^\\[package\\]/,/^\\[/{s/^version = \".*\"/version = \"${nextRelease.version}\"/;}' Cargo.toml && cargo update --package dotsnapshot --precise \"${nextRelease.version}\""
       }
     ],
     [

--- a/test-releaserc-command.sh
+++ b/test-releaserc-command.sh
@@ -37,7 +37,7 @@ echo "🔄 Testing with nextRelease.version = $nextRelease_version"
 
 # Test the exact command from .releaserc.json (without cargo update to avoid dependency issues)
 # Using environment variable substitution like semantic-release does
-PREPARE_CMD="sed -i.bak 's/^version = \"[^\"]*\"/version = \"${nextRelease_version}\"/' test-Cargo.toml"
+PREPARE_CMD="sed -i.bak '/^\[package\]/,/^\[/{s/^version = \".*\"/version = \"${nextRelease_version}\"/;}' test-Cargo.toml"
 
 echo "📋 Executing: $PREPARE_CMD"
 eval "$PREPARE_CMD"


### PR DESCRIPTION
Fixes semantic-release by ensuring only the package version is updated, not dependency versions.