### PR TITLE
fix: Remove semantic-release git plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@
 # 2. Determine version bump (patch/minor/major) based on commit types
 # 3. Update Cargo.toml version and generate CHANGELOG.md
 # 4. Create GitHub release with generated binaries
-# 5. Commit changes back to main with [skip ci]
 
 name: Release
 
@@ -229,7 +228,6 @@ jobs:
         # 4. Updates Cargo.toml version using @semantic-release/exec
         # 5. Generates CHANGELOG.md using @semantic-release/changelog  
         # 6. Creates GitHub release with binaries using @semantic-release/github
-        # 7. Commits updated files back to main using @semantic-release/git
-        run: npx -p semantic-release -p @semantic-release/changelog -p @semantic-release/git -p @semantic-release/github -p @semantic-release/exec semantic-release
+        run: npx -p semantic-release -p @semantic-release/changelog -p @semantic-release/github -p @semantic-release/exec semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Required for GitHub API access

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -29,13 +29,6 @@
           }
         ]
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["Cargo.toml", "Cargo.lock", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\\n\\n${nextRelease.notes}"
-      }
     ]
   ]
 }


### PR DESCRIPTION
## Summary
- Removes the @semantic-release/git plugin from .releaserc.json to prevent "pushing refs to main" failures
- Updates workflow comments to reflect that changes are no longer committed back to main
- Semantic-release will still update files and create releases without trying to push changes back

## Problem
The @semantic-release/git plugin was attempting to commit updated files (Cargo.toml, Cargo.lock, CHANGELOG.md) back to the main branch after creating releases, which was being blocked by branch protection rules or workflow permissions.

## Solution
Remove the git plugin entirely. Semantic-release will still:
- Update Cargo.toml version during the release process
- Generate CHANGELOG.md
- Create GitHub releases with binaries
- But it won't try to commit these changes back to main

## Test plan
- [ ] Merge this PR
- [ ] Test that semantic-release now completes successfully without the "pushing refs to main" error
- [ ] Verify that releases are still created properly with all assets

🤖 Generated with [Claude Code](https://claude.ai/code)