### PR TITLE
fix: Use PowerShell Compress-Archive for Windows ZIP packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,13 +128,14 @@ jobs:
 
       - name: Package binary into archive
         id: package
+        shell: bash
         run: |
           PKG_BASENAME="dotsnapshot-${{ matrix.job.target }}"
           case ${{ matrix.job.target }} in
             *-pc-windows-*) 
-              # Windows: Create ZIP with .exe
+              # Windows: Create ZIP with .exe using PowerShell
               PKG_NAME="$PKG_BASENAME.zip"
-              7z a "$PKG_NAME" ./target/${{ matrix.job.target }}/release/dotsnapshot.exe
+              powershell "Compress-Archive -Path './target/${{ matrix.job.target }}/release/dotsnapshot.exe' -DestinationPath '$PKG_NAME'"
               ;;
             *)
               # Unix: Create tar.gz with binary


### PR DESCRIPTION
## Summary
- Replaces 7z with PowerShell's built-in Compress-Archive cmdlet for Windows builds
- Adds explicit `shell: bash` to ensure consistent behavior across platforms
- Fixes Windows build failures in the release workflow

## Problem
The Windows build was failing because 7z is not available by default on GitHub Windows runners. The error was:
```
7z a "$PKG_NAME" ./target/${{ matrix.job.target }}/release/dotsnapshot.exe
```

## Solution
Use PowerShell's built-in `Compress-Archive` cmdlet instead:
```powershell
powershell "Compress-Archive -Path './target/${{ matrix.job.target }}/release/dotsnapshot.exe' -DestinationPath '$PKG_NAME'"
```

This is available by default on all Windows runners and produces the same ZIP format.

## Test plan
- [ ] Merge this PR
- [ ] Trigger a release build
- [ ] Verify Windows build completes successfully
- [ ] Check that Windows ZIP file is created properly with dotsnapshot.exe inside

Fixes the Windows build failure from: https://github.com/tomerlichtash/dotsnapshot/actions/runs/16402844217/job/46344699415

🤖 Generated with [Claude Code](https://claude.ai/code)