### PR TITLE
fix: Add shell: bash to SHA256 checksum step for Windows compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,7 @@ jobs:
           echo "pkg-name=$PKG_NAME" >> $GITHUB_OUTPUT
 
       - name: Generate SHA256 checksum
+        shell: bash
         run: |
           case ${{ runner.os }} in
             Windows) 


### PR DESCRIPTION
## Summary
Fixes the final Windows packaging issue by adding `shell: bash` to the SHA256 checksum generation step.

## Problem
The Windows build is failing on the "Generate SHA256 checksum" step because it's trying to run bash case syntax (`case ${{ runner.os }} in`) in PowerShell, which doesn't understand this syntax.

## Solution
Add `shell: bash` to the SHA256 checksum step to ensure it runs consistently across all platforms (Linux, macOS, Windows).

## Current Status
✅ Test step - working
✅ Build step - working  
✅ Package step - working (PowerShell Compress-Archive)
❌ SHA256 step - failing (this fixes it)
⏳ Upload step - pending

## Test plan
- [ ] Merge this PR
- [ ] Verify Windows build completes successfully through all steps
- [ ] Check that Windows ZIP file and SHA256 checksum are created properly
- [ ] Confirm all 5 platforms build successfully

This should be the final fix needed for complete multi-platform release support.

🤖 Generated with [Claude Code](https://claude.ai/code)