### PR TITLE
fix: Add shell: bash to SHA256 checksum step for Windows compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,7 @@ jobs:
           echo "pkg-name=$PKG_NAME" >> $GITHUB_OUTPUT
 
       - name: Generate SHA256 checksum
+        shell: bash
         run: |
           case ${{ runner.os }} in
             Windows) 


### PR DESCRIPTION
## Summary
This applies the missing SHA256 fix from the fix/test-script-paths branch that didn't get included in PR #85.

## Problem
Windows builds are still failing on the SHA256 checksum step because it lacks `shell: bash`, causing bash syntax to run in PowerShell.

## Solution  
Cherry-picked the SHA256 fix (commit 0298bf7) from fix/test-script-paths branch to complete the Windows packaging process.

## What this completes
✅ Test step - working (from PR #85)
✅ Build step - working (from PR #85)  
✅ Package step - working (from PR #85)
❌ SHA256 step - this fixes it
⏳ Upload step - should work after this

This is the final piece needed for complete Windows packaging support.

🤖 Generated with [Claude Code](https://claude.ai/code)