### PR TITLE
feat: Add custom target paths for all plugins

### DIFF
--- a/dotsnapshot.toml
+++ b/dotsnapshot.toml
@@ -8,7 +8,41 @@ output_dir = "./.snapshots"
 # Available plugins: homebrew, vscode, cursor, npm, static
 # include_plugins = ["homebrew", "vscode", "static"]
 
-# Static plugin configuration
+# Custom plugin target paths - allows plugins to write to custom directories in snapshots
+[plugins]
+# VSCode plugins can share the same directory
+vscode_settings = { target_path = "vscode" }
+vscode_keybindings = { target_path = "vscode" }
+vscode_extensions = { target_path = "vscode" }
+
+# Cursor plugins can share the same directory
+cursor_settings = { target_path = "cursor" }
+cursor_keybindings = { target_path = "cursor" }
+cursor_extensions = { target_path = "cursor" }
+
+# Homebrew plugin
+homebrew_brewfile = { target_path = "homebrew" }
+
+# NPM plugins
+npm_global_packages = { target_path = "npm" }
+npm_config = { target_path = "npm" }
+
+# Static files plugin with custom path and additional configuration
+# [plugins.static]
+# target_path = "my-dotfiles"
+# files = [
+#   "~/.zshrc",
+#   "~/.gitconfig",
+#   "~/dotfiles",
+# ]
+# ignore = [
+#   ".git",
+#   "*.key",
+#   "*_rsa",
+#   "known_hosts*",
+# ]
+
+# Legacy static plugin configuration (still supported for backward compatibility)
 [static]
 # files = [
 #   "~/.zshrc",

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,21 +38,21 @@ pub struct LoggingConfig {
 pub struct PluginsConfig {
     /// Homebrew plugin configurations
     pub homebrew_brewfile: Option<PluginConfig>,
-    
+
     /// VSCode plugin configurations
     pub vscode_settings: Option<PluginConfig>,
-    pub vscode_keybindings: Option<PluginConfig>, 
+    pub vscode_keybindings: Option<PluginConfig>,
     pub vscode_extensions: Option<PluginConfig>,
-    
+
     /// Cursor plugin configurations
     pub cursor_settings: Option<PluginConfig>,
     pub cursor_keybindings: Option<PluginConfig>,
     pub cursor_extensions: Option<PluginConfig>,
-    
+
     /// NPM plugin configurations
     pub npm_global_packages: Option<PluginConfig>,
     pub npm_config: Option<PluginConfig>,
-    
+
     /// Static files plugin configuration
     #[serde(rename = "static")]
     pub static_files: Option<StaticPluginConfig>,
@@ -206,7 +206,7 @@ impl Config {
     /// Get plugin target path for a specific plugin
     pub fn get_plugin_target_path(&self, plugin_name: &str) -> Option<String> {
         let plugins = self.plugins.as_ref()?;
-        
+
         match plugin_name {
             "homebrew_brewfile" => plugins.homebrew_brewfile.as_ref()?.target_path.clone(),
             "vscode_settings" => plugins.vscode_settings.as_ref()?.target_path.clone(),
@@ -220,11 +220,6 @@ impl Config {
             "static" => plugins.static_files.as_ref()?.target_path.clone(),
             _ => None,
         }
-    }
-
-    /// Get new static files configuration
-    pub fn get_static_plugin_config(&self) -> Option<&StaticPluginConfig> {
-        self.plugins.as_ref()?.static_files.as_ref()
     }
 
     /// Save configuration to file

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,9 +15,12 @@ pub struct Config {
     /// Logging configuration
     pub logging: Option<LoggingConfig>,
 
-    /// Static plugin configuration
+    /// Static plugin configuration (legacy)
     #[serde(rename = "static")]
     pub static_files: Option<StaticFilesConfig>,
+
+    /// Plugin-specific configurations
+    pub plugins: Option<PluginsConfig>,
 }
 
 /// Logging configuration
@@ -30,7 +33,50 @@ pub struct LoggingConfig {
     pub time_format: Option<String>,
 }
 
-/// Static files plugin configuration
+/// Plugin-specific configurations
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PluginsConfig {
+    /// Homebrew plugin configurations
+    pub homebrew_brewfile: Option<PluginConfig>,
+    
+    /// VSCode plugin configurations
+    pub vscode_settings: Option<PluginConfig>,
+    pub vscode_keybindings: Option<PluginConfig>, 
+    pub vscode_extensions: Option<PluginConfig>,
+    
+    /// Cursor plugin configurations
+    pub cursor_settings: Option<PluginConfig>,
+    pub cursor_keybindings: Option<PluginConfig>,
+    pub cursor_extensions: Option<PluginConfig>,
+    
+    /// NPM plugin configurations
+    pub npm_global_packages: Option<PluginConfig>,
+    pub npm_config: Option<PluginConfig>,
+    
+    /// Static files plugin configuration
+    #[serde(rename = "static")]
+    pub static_files: Option<StaticPluginConfig>,
+}
+
+/// Generic plugin configuration
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PluginConfig {
+    /// Custom target path in snapshot (relative to snapshot root)
+    pub target_path: Option<String>,
+}
+
+/// Static files plugin configuration with additional options
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct StaticPluginConfig {
+    /// Custom target path in snapshot (relative to snapshot root)
+    pub target_path: Option<String>,
+    /// List of file paths to include in snapshots
+    pub files: Option<Vec<String>>,
+    /// Glob patterns to ignore when copying files/directories
+    pub ignore: Option<Vec<String>>,
+}
+
+/// Static files plugin configuration (legacy)
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StaticFilesConfig {
     /// List of file paths to include in snapshots
@@ -46,6 +92,7 @@ impl Default for Config {
             include_plugins: None,
             logging: None,
             static_files: None,
+            plugins: None,
         }
     }
 }
@@ -151,9 +198,33 @@ impl Config {
             .unwrap_or_else(|| "[year]-[month]-[day] [hour]:[minute]:[second]".to_string())
     }
 
-    /// Get static files configuration
+    /// Get static files configuration (legacy)
     pub fn get_static_files(&self) -> Option<&StaticFilesConfig> {
         self.static_files.as_ref()
+    }
+
+    /// Get plugin target path for a specific plugin
+    pub fn get_plugin_target_path(&self, plugin_name: &str) -> Option<String> {
+        let plugins = self.plugins.as_ref()?;
+        
+        match plugin_name {
+            "homebrew_brewfile" => plugins.homebrew_brewfile.as_ref()?.target_path.clone(),
+            "vscode_settings" => plugins.vscode_settings.as_ref()?.target_path.clone(),
+            "vscode_keybindings" => plugins.vscode_keybindings.as_ref()?.target_path.clone(),
+            "vscode_extensions" => plugins.vscode_extensions.as_ref()?.target_path.clone(),
+            "cursor_settings" => plugins.cursor_settings.as_ref()?.target_path.clone(),
+            "cursor_keybindings" => plugins.cursor_keybindings.as_ref()?.target_path.clone(),
+            "cursor_extensions" => plugins.cursor_extensions.as_ref()?.target_path.clone(),
+            "npm_global_packages" => plugins.npm_global_packages.as_ref()?.target_path.clone(),
+            "npm_config" => plugins.npm_config.as_ref()?.target_path.clone(),
+            "static" => plugins.static_files.as_ref()?.target_path.clone(),
+            _ => None,
+        }
+    }
+
+    /// Get new static files configuration
+    pub fn get_static_plugin_config(&self) -> Option<&StaticPluginConfig> {
+        self.plugins.as_ref()?.static_files.as_ref()
     }
 
     /// Save configuration to file
@@ -205,6 +276,7 @@ mod tests {
                 files: Some(vec!["~/.gitconfig".to_string(), "/etc/hosts".to_string()]),
                 ignore: None,
             }),
+            plugins: None,
         };
 
         // Save config

--- a/src/core/executor.rs
+++ b/src/core/executor.rs
@@ -17,6 +17,7 @@ pub struct SnapshotExecutor {
 }
 
 impl SnapshotExecutor {
+    #[allow(dead_code)]
     pub fn new(registry: Arc<PluginRegistry>, base_path: PathBuf) -> Self {
         Self {
             registry,
@@ -25,7 +26,11 @@ impl SnapshotExecutor {
         }
     }
 
-    pub fn with_config(registry: Arc<PluginRegistry>, base_path: PathBuf, config: Arc<Config>) -> Self {
+    pub fn with_config(
+        registry: Arc<PluginRegistry>,
+        base_path: PathBuf,
+        config: Arc<Config>,
+    ) -> Self {
         Self {
             registry,
             snapshot_manager: SnapshotManager::new(base_path),
@@ -55,8 +60,13 @@ impl SnapshotExecutor {
             let config_clone = self.config.clone();
 
             let task = tokio::spawn(async move {
-                Self::execute_plugin(plugin_clone, &snapshot_dir_clone, &snapshot_manager_clone, config_clone.as_deref())
-                    .await
+                Self::execute_plugin(
+                    plugin_clone,
+                    &snapshot_dir_clone,
+                    &snapshot_manager_clone,
+                    config_clone.as_deref(),
+                )
+                .await
             });
 
             plugin_tasks.push(task);
@@ -275,8 +285,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_snapshot_with_custom_plugin_paths() -> Result<()> {
-        use crate::config::{Config, PluginsConfig, PluginConfig};
-        
+        use crate::config::{Config, PluginConfig, PluginsConfig};
+
         let temp_dir = TempDir::new()?;
         let base_path = temp_dir.path().to_path_buf();
 
@@ -314,11 +324,12 @@ mod tests {
             content: "vscode extensions content".to_string(),
         }));
 
-        let executor = SnapshotExecutor::with_config(Arc::new(registry), base_path, Arc::new(config));
+        let executor =
+            SnapshotExecutor::with_config(Arc::new(registry), base_path, Arc::new(config));
         let snapshot_dir = executor.execute_snapshot().await?;
 
         assert!(snapshot_dir.exists());
-        
+
         // Both plugins should be in the vscode directory due to shared target_path
         assert!(snapshot_dir.join("vscode").join("test.txt").exists());
         assert!(snapshot_dir

--- a/src/core/plugin.rs
+++ b/src/core/plugin.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use crate::config::Config;
 
 /// Represents the result of a plugin execution
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,6 +36,19 @@ pub trait Plugin: Send + Sync {
     /// Returns the expected output file path for this plugin
     fn output_path(&self, base_path: &Path) -> PathBuf {
         base_path.join(self.filename())
+    }
+
+    /// Returns the expected output file path with custom configuration support
+    fn output_path_with_config(&self, base_path: &Path, config: Option<&Config>) -> PathBuf {
+        // Check if there's a custom target path configured for this plugin
+        if let Some(config) = config {
+            if let Some(custom_path) = config.get_plugin_target_path(self.name()) {
+                return base_path.join(custom_path).join(self.filename());
+            }
+        }
+        
+        // Fall back to default behavior if no custom path is configured
+        self.output_path(base_path)
     }
 }
 

--- a/src/core/plugin.rs
+++ b/src/core/plugin.rs
@@ -1,9 +1,9 @@
+use crate::config::Config;
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use crate::config::Config;
 
 /// Represents the result of a plugin execution
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -46,7 +46,7 @@ pub trait Plugin: Send + Sync {
                 return base_path.join(custom_path).join(self.filename());
             }
         }
-        
+
         // Fall back to default behavior if no custom path is configured
         self.output_path(base_path)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -349,7 +349,7 @@ async fn main() -> Result<()> {
     }
 
     // Create executor and run snapshot
-    let executor = SnapshotExecutor::new(Arc::new(registry), output_dir);
+    let executor = SnapshotExecutor::with_config(Arc::new(registry), output_dir, Arc::new(config));
 
     match executor.execute_snapshot().await {
         Ok(snapshot_path) => {

--- a/src/plugins/static_files/plugin.rs
+++ b/src/plugins/static_files/plugin.rs
@@ -474,6 +474,7 @@ mod tests {
                 files: Some(vec!["/etc/hosts".to_string()]),
                 ignore: None,
             }),
+            plugins: None,
         };
 
         let plugin = StaticFilesPlugin::with_config(Arc::new(config));


### PR DESCRIPTION
## Summary
- Implement generic plugin configuration system allowing custom target paths
- All plugins can now specify custom output directories in snapshots
- Related plugins can share the same directory (e.g., vscode_settings and vscode_extensions both in "vscode/")

## Configuration Examples
```toml
[plugins]
# VSCode plugins sharing a directory
vscode_settings = { target_path = "vscode" }
vscode_extensions = { target_path = "vscode" }

# Group by vendor
homebrew_brewfile = { target_path = "homebrew" }

# Custom static files path
[plugins.static]
target_path = "my-dotfiles"
files = ["~/.zshrc", "~/.gitconfig"]
```

## Test Plan
- [x] All plugins respect custom target_path configuration
- [x] Multiple plugins can share the same target directory
- [x] Backward compatibility maintained for existing configurations
- [x] Comprehensive test coverage added for custom paths
- [x] Configuration examples updated in dotsnapshot.toml

🤖 Generated with [Claude Code](https://claude.ai/code)