### PR TITLE
chore: Add code formatting enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,16 @@ cargo test
 
 This project uses `rustfmt` for consistent code formatting. Run `cargo fmt --all` to format your code before committing. The CI will check formatting and fail if code is not properly formatted.
 
+#### Optional: Pre-commit Hook
+
+To automatically format code before each commit, you can install a pre-commit hook:
+
+```bash
+./scripts/install-hooks.sh
+```
+
+This will prevent you from committing unformatted code and automatically run `cargo fmt --all` before each commit.
+
 ### Adding New Plugins
 
 1. Create a new vendor directory in `src/plugins/` (e.g., `src/plugins/git/`)

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ cargo test
 
 ### Code Formatting
 
-This project uses `rustfmt` for consistent code formatting. A pre-commit hook is available to automatically format code before commits.
+This project uses `rustfmt` for consistent code formatting. Run `cargo fmt --all` to format your code before committing. The CI will check formatting and fail if code is not properly formatted.
 
 ### Adding New Plugins
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,10 @@ Each plugin focuses on a single concern and can be executed independently.
 cargo test
 ```
 
+### Code Formatting
+
+This project uses `rustfmt` for consistent code formatting. A pre-commit hook is available to automatically format code before commits.
+
 ### Adding New Plugins
 
 1. Create a new vendor directory in `src/plugins/` (e.g., `src/plugins/git/`)

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,19 @@
+# Rust formatting configuration for dotsnapshot
+# See https://rust-lang.github.io/rustfmt/ for all options
+# Only using stable rustfmt features
+
+# Basic formatting
+max_width = 100
+hard_tabs = false
+tab_spaces = 4
+newline_style = "Unix"
+use_small_heuristics = "Default"
+
+# Imports (stable subset)
+reorder_imports = true
+
+# Functions and control flow
+force_explicit_abi = true
+
+# Edition
+edition = "2021"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -6,7 +6,7 @@
 max_width = 100
 hard_tabs = false
 tab_spaces = 4
-newline_style = "Unix"
+newline_style = "Auto"
 use_small_heuristics = "Default"
 
 # Imports (stable subset)

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Install pre-commit hooks for dotsnapshot development
+#
+# This script installs a pre-commit hook that automatically runs cargo fmt
+# and prevents commits if the code is not properly formatted.
+#
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${YELLOW}Installing pre-commit hooks for dotsnapshot...${NC}"
+
+# Check if we're in a git repository
+if [ ! -d ".git" ]; then
+    echo -e "${RED}Error: Not in a git repository. Please run this script from the project root.${NC}"
+    exit 1
+fi
+
+# Check if cargo is available
+if ! command -v cargo &> /dev/null; then
+    echo -e "${RED}Error: cargo command not found. Please install Rust and Cargo.${NC}"
+    exit 1
+fi
+
+# Create hooks directory if it doesn't exist
+mkdir -p .git/hooks
+
+# Create the pre-commit hook
+cat > .git/hooks/pre-commit << 'EOF'
+#!/bin/sh
+#
+# Pre-commit hook that runs cargo fmt and fails if code is not formatted
+#
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "${YELLOW}Running cargo fmt...${NC}"
+
+# Run cargo fmt
+cargo fmt --all
+
+# Check if there are any changes after formatting (check working directory changes)
+if ! git diff --quiet; then
+    echo "${RED}❌ Code was not properly formatted!${NC}"
+    echo "${YELLOW}The following files have been formatted:${NC}"
+    git diff --name-only
+    echo ""
+    echo "${YELLOW}Please add the formatted files and commit again:${NC}"
+    echo "  git add ."
+    echo "  git commit"
+    exit 1
+fi
+
+echo "${GREEN}✅ Code is properly formatted${NC}"
+exit 0
+EOF
+
+# Make the hook executable
+chmod +x .git/hooks/pre-commit
+
+echo -e "${GREEN}✅ Pre-commit hook installed successfully!${NC}"
+echo ""
+echo "The hook will:"
+echo "  • Run 'cargo fmt --all' before each commit"
+echo "  • Block commits if code is not properly formatted"
+echo "  • Show which files were formatted and provide clear instructions"
+echo ""
+echo -e "${YELLOW}To uninstall the hook, simply delete:${NC} .git/hooks/pre-commit"

--- a/src/plugins/homebrew/mod.rs
+++ b/src/plugins/homebrew/mod.rs
@@ -1,4 +1,3 @@
 pub mod brewfile;
 
-
-pub use    brewfile::HomebrewBrewfilePlugin;
+pub use brewfile::HomebrewBrewfilePlugin;

--- a/src/plugins/homebrew/mod.rs
+++ b/src/plugins/homebrew/mod.rs
@@ -1,3 +1,4 @@
 pub mod brewfile;
 
-pub use brewfile::HomebrewBrewfilePlugin;
+
+pub use    brewfile::HomebrewBrewfilePlugin;


### PR DESCRIPTION
## Summary
- Add rustfmt.toml configuration for consistent code formatting
- Create local pre-commit hook to enforce formatting before commits
- Leverage existing CI formatting check (cargo fmt --check)

## Changes
- **rustfmt.toml**: Formatting rules using only stable rustfmt features
- **Pre-commit hook**: Automatically runs cargo fmt and prevents unformatted commits
- **Documentation**: Clear instructions for consistent formatting

## Three-layer approach
1. **Local pre-commit hook**: Prevents unformatted code from being committed
2. **CI formatting check**: Existing check ensures PRs have properly formatted code  
3. **rustfmt.toml**: Ensures consistent formatting rules across team

## Test Plan
- [x] Pre-commit hook successfully prevents unformatted commits
- [x] rustfmt.toml uses only stable features (no nightly required)
- [x] Existing CI check continues to work
- [x] Hook provides clear feedback when formatting is needed

🤖 Generated with [Claude Code](https://claude.ai/code)